### PR TITLE
textDocument/hover implementation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,5 +1,12 @@
 {
     "version": "0.1.0",
     "configurations": [
+        {
+            "name": "LSP",
+            "type": "erlang",
+            "request": "launch",
+            "cwd": "${workspaceRoot}",
+            "arguments": "-pa _build/default/lib/*/ebin -eval \"erlang_ls:main([])\""
+        }
     ]
 }

--- a/apps/sourcer/src/sourcer_documents.erl
+++ b/apps/sourcer/src/sourcer_documents.erl
@@ -51,7 +51,7 @@ parse_file(File, Text) ->
     Mod = list_to_atom(unicode:characters_to_list(File)),
     {ok, Toks, _} = sourcer_scan:string(TText),
     Forms = sourcer_parse:parse(Toks),
-    Db = sourcer_db:analyze(Forms),
+    Db = sourcer_db:analyse(Forms),
     Db.
 
 process_file(URI, Text) ->
@@ -68,12 +68,12 @@ process_watched(#{uri:=URI, type:=3}, List) ->
 
 get_element(Data, URI, #{character:=C, line:=L}) ->
     Model = get_model(Data, URI),
-    
-    %Lines = sourcer_scan:line_info(Data#)
-    %{Ofs,Len,_} = get_line_info(L, Lines),
-    %% FIXME!
-    Refs2 = [], 
-    %io:format("refs2 ~p ~n", [Refs2]),
+    {#model{defs=D, refs=R}, _} = Model,
+    Fun =
+        fun({_,{{SL, SC},{EL, EC}},_,_}) when SL =< L, SC =< C, EL >= L, EC >= C -> true; %defs
+        ({_, {{SL, SC},{EL, EC}}}) when SL =< L, SC =< C, EL >= L, EC >= C -> true; %refs
+        (_)-> false end,
+    Refs2 = lists:filter(Fun, D ++ R),
     case Refs2 of
         [] -> [];
         _ -> lists:last(Refs2)

--- a/apps/sourcer/src/sourcer_util.erl
+++ b/apps/sourcer/src/sourcer_util.erl
@@ -1,7 +1,8 @@
 -module(sourcer_util).
 
 -export([pack/1, unpack/1, join/2]).
--export([reverse2/1]).
+-export([reverse2/1, take_right/2]).
+-export([binary_join/2]).
 
 -export([get_auto_imported/1, add_auto_imported/1]).
 
@@ -38,3 +39,17 @@ get_auto_imported(Prefix) when is_list(Prefix) ->
             error
     end.
 
+take_right(L, N) ->
+  lists:reverse(lists:sublist(lists:reverse(L), N)).    
+
+binary_join([], _Sep) ->
+  <<>>;
+binary_join([Part], _Sep) ->
+  Part;
+binary_join(List, Sep) ->
+  lists:foldr(fun(A, B) ->
+    if
+      bit_size(B) > 0 -> <<A/binary, Sep/binary, B/binary>>;
+      true -> A
+    end 
+              end, <<>>, List).

--- a/apps/sourcer/test/sourcer_documents_tests.erl
+++ b/apps/sourcer/test/sourcer_documents_tests.erl
@@ -54,22 +54,22 @@ parse_file_test_1() ->
         ?_assertEqual(TextLines, Chunks)
     ].
 
-get_element_test_000() ->
+get_element_test_() ->
     Text = text(),
-    {ok, AST, Refs, Lines} = sourcer_documents:parse_file("foo1", Text),
-    Open = [{<<"foo">>, Text, {AST, Refs, Lines}}],
+    Model = sourcer_documents:parse_file("foo1", Text),
+    Open = [{<<"foo">>, Text, {Model, []}}],
     [
         ?_assertMatch([],
                         sourcer_documents:get_element(Open, <<"foo">>, #{line=>0, character=>0})
                     ),
-        ?_assertMatch({ref,{module_def,"foo"},1,13,module,-3,[],false},
-                        sourcer_documents:get_element(Open, <<"foo">>, #{line=>1, character=>1})
+        ?_assertMatch({[{module,foo}],{{1,9},{1,12}},none,#{}},
+                        sourcer_documents:get_element(Open, <<"foo">>, #{line=>1, character=>9})
                     ),
-        ?_assertMatch({ref,{function_def,bar,0},15,3,bar,0,[],false},
+        ?_assertMatch({[{module,foo},{function,bar,0}],{{2,1},{2,4}},{{2,1},{3,11}},#{}},
                         sourcer_documents:get_element(Open, <<"foo">>, #{line=>2, character=>1})
                     ),
-        ?_assertMatch({ref,{function_def,quz,1},36,3,quz,1,[],false},
-                        sourcer_documents:get_element(Open, <<"foo">>, #{line=>5, character=>1})
+        ?_assertMatch({[{module,foo},{function,quz,1}],{{4,1},{4,4}},{{4,1},{7,7}},#{}},
+                        sourcer_documents:get_element(Open, <<"foo">>, #{line=>4, character=>1})
                     )
     ].
 

--- a/apps/sourcer/test/sourcer_util_tests.erl
+++ b/apps/sourcer/test/sourcer_util_tests.erl
@@ -1,3 +1,17 @@
 -module(sourcer_util_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+
+take_right_test_() ->
+  [
+    ?_assertEqual([], sourcer_util:take_right([], 2)),
+    ?_assertEqual([3 ,4], sourcer_util:take_right([1, 2, 3, 4], 2)),
+    ?_assertEqual([1, 2, 3 ,4], sourcer_util:take_right([1, 2, 3, 4], 5))
+  ].
+
+binary_join_test_() ->
+  [
+    ?_assertEqual(<<"a1,a2,a3">>, sourcer_util:binary_join([<<"a1">>, <<"a2">>, <<"a3">>], <<",">>)),
+    ?_assertEqual(<<"a1">>, sourcer_util:binary_join([<<"a1">>], <<",">>)),
+    ?_assertEqual(<<>>, sourcer_util:binary_join([], <<",">>))
+  ]. 


### PR DESCRIPTION
Implementation of `sourcer_documents:get_element/3` and part of `textDocument/hover` command.
Want to add `spec` declaration into hover message, but I do not understand how `spec` token will be in Model structure, now it puts only in refs like a `function`. Maybe it also put to defs part too, but many tests check current state.
