### PR TITLE
Accept other values for transport when setting extra env variables

### DIFF
--- a/apps/erlang_ls/src/erlang_ls.erl
+++ b/apps/erlang_ls/src/erlang_ls.erl
@@ -64,7 +64,9 @@ start_server(Opts, Config) ->
     case Transport of
         tcp ->
             Port = maps:get(port, Opts, proplists:get_value(port, Config, ?DEFAULT_PORT)),
-            ok = application:set_env(lsp_server, port, Port)
+            ok = application:set_env(lsp_server, port, Port);
+        _ ->
+            ok
     end,
     ok = application:set_env(lsp_server, implementor, sourcer),
 


### PR DESCRIPTION
This doesn't get things totally working, but it allows the server to start. However, the server fails silently after int.

```
*[i] trunk ~/code/projects/condorcet ; erlang_ls --transport stdio -vvvv
LSP: Start connection on stdio
{"jsonrpc":"2.0","method":"initialize","params":{"capabilities":{"textDocument":{},"workspace":{"applyEdit":null,"didChangeConfiguration":null,"didChangeWatchedFiles":null,"executeCommand":null,"symbol":null,"workspaceEdit":null}},"processId":31336,"rootPath":"/home/zax/code/projects/condorcet","rootUri":"file:///home/zax/code/projects/condorcet","trace":"off"},"id":0}
```

The process silently terminates after that.